### PR TITLE
Custom Criteria Done.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build
+name: build
 
 on:
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,4 +11,6 @@
 
 ## 0.2.0
 
-* Use custom criteria.
+* Use custom criteria. Use string keys to indicate custom criteria, e.g. `made_purchase`.
+* Make cool down intervals nullable.
+* More tests.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ For major changes, please open an issue first to discuss what you would like to 
 ## TODO
 
 - [x] Determine if user should be prompted for a review based on a custom criteria.
-- [ ]  
+- [ ] Determine if user should be prompted for a review based on aggregated custom criteria.
 - [ ] Get next prompt date.
 - [x] Get number of times app launched.
 - [ ] Get number of days since first launch.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ if (await ShouldReview.shouldReview(
     ShouldReview.neverReview(); // This ensures the shouldReview function never returns true again.
 }
 ```
-__NB:__ For the above to work as expected, there is one thing you have to put in place, which is the `recordLaunch` function.
+
+**NB:** For the above to work as expected, there is one thing you have to put in place, which is the `recordLaunch` function.
 
 The `recordLaunch` function must be called somewhere in your app that runs once the app is launched. Suitably in your `lib\main.dart` file or in the `initState` of your Dashboard widget for instance.
 
@@ -83,17 +84,24 @@ if (await ShouldReview.shouldReview(
 }
 ```
 
-__NB:__ The `shouldReview` function can only return `true` __once__ a day.
+**NB:** The `shouldReview` function can only return `true` **once** a day.
 
 ### Parameters
 
-| Parameter             | Description                                                                                                                                                                                                                                                 | Example                                   |
-|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------|
-| `criteria`            | The criteria to use for determining if you should prompt a user for review.                                                                                                                                                                                 | `Criteria.days`, `Criteria.timesLaunched` |
-| `minDays`             | The minimum number of days since first app launch to prompt a user for review.                                                                                                                                                                              | `5`, `8`, `2`                             |
-| `coolDownDays`        | The number of days after the minimum days has elapsed to prompt a user for review. In other words, if you provided `2` to this parameter, it means that every `2` days, the `shouldReview` function will return true if `neverReview` has not been called. | `2`, `3`, `1`                             |
-| `minLaunchTimes`      | The number of times the app has to be launched before the `shouldReview` function can return true.                                                                                                                                                          | `8`, `5`                                  |
-| `coolDownLaunchTimes` | same as `coolDownDays` but for the launch times criteria.                                                                                                                                                                                                   | `3`, `5`                                  |
+| Parameter                        | Description                                                                                                                                                                                                                                                | Example                                   | Default         |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | --------------- |
+| `criteria`                       | The criteria to use for determining if you should prompt a user for review.                                                                                                                                                                                | `Criteria.days`, `Criteria.timesLaunched` | `Criteria.days` |
+| `minDays`                        | The minimum number of days since first app launch to prompt a user for review.                                                                                                                                                                             | `5`, `8`, `2`                             | `5`             |
+| `coolDownDays`                   | The number of days after the minimum days has elapsed to prompt a user for review. In other words, if you provided `2` to this parameter, it means that every `2` days, the `shouldReview` function will return true if `neverReview` has not been called. | `2`, `3`, `1`                             | `2`             |
+| `minLaunchTimes`                 | The number of times the app has to be launched before the `shouldReview` function can return true.                                                                                                                                                         | `8`, `5`                                  | `5`             |
+| `coolDownLaunchTimes`            | Same as `coolDownDays` but for the launch times criteria.                                                                                                                                                                                                  | `3`, `5`                                  | `4`             |
+| `minCustomCriteriaValue`         | The minimum value for the given a given custom criterion.                                                                                                                                                                                                  | `3`, `10`                                 | `null`          |
+| `coolDownCustomCriteriaInterval` | Cool down interval value for custom criteria. Similar to `coolDownDays` and `coolDownLaunchTimes`.                                                                                                                                                         | `2`, `5`                                  | `null`          |
+| `customCriteriaKey`              | Custom Criteria Key                                                                                                                                                                                                                                        | `made_purchase`, `advanced_a_level`, etc. | `null`          |
+
+**NB:** `minCustomCriteriaValue` and `customCriteriaKey` are when criteria is set to `Criteria.custom`. Not providing the two values in this scenario will result in an error.
+
+**NB:** The `coolDown...` parameters are nullable. passing null to them will ignore all cool down logic and return false all through.
 
 ## Additional information
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -59,126 +59,138 @@ class _MyHomePageState extends State<MyHomePage> {
       appBar: AppBar(
         title: Text(widget.title),
       ),
-      body: Container(
-        padding: const EdgeInsets.all(10),
-        alignment: Alignment.center,
-        child: Form(
-          key: _daysCriteriaFormKey,
-          child: Column(
-            children: [
-              const Text(
-                  "Determine if user should rate app by past days after first launch"),
-              const SizedBox(
-                height: 20,
-              ),
-              Row(
-                children: [
-                  Expanded(
-                    child: TextFormField(
-                      controller: _minDaysController,
-                      keyboardType: TextInputType.number,
-                      inputFormatters: [
-                        FilteringTextInputFormatter.allow(RegExp("[0-9]")),
-                      ],
-                      validator: (value) {
-                        if (value == null ||
-                            value.isEmpty ||
-                            int.tryParse(value) == null) {
-                          return 'Please enter a number';
-                        }
-                        return null;
-                      },
-                      decoration: const InputDecoration(
-                          label: Text('Minimum Days before First Prompt'),
-                          border: OutlineInputBorder(borderSide: BorderSide())),
+      body: SingleChildScrollView(
+        child: Container(
+          padding: const EdgeInsets.all(10),
+          alignment: Alignment.center,
+          child: Form(
+            key: _daysCriteriaFormKey,
+            child: Column(
+              children: [
+                const Text(
+                    "Determine if user should rate app by past days after first launch"),
+                const SizedBox(
+                  height: 20,
+                ),
+                Row(
+                  children: [
+                    Expanded(
+                      child: TextFormField(
+                        controller: _minDaysController,
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp("[0-9]")),
+                        ],
+                        validator: (value) {
+                          if (value == null ||
+                              value.isEmpty ||
+                              int.tryParse(value) == null) {
+                            return 'Please enter a number';
+                          }
+                          return null;
+                        },
+                        decoration: const InputDecoration(
+                            label: Text('Minimum Days before First Prompt'),
+                            border:
+                                OutlineInputBorder(borderSide: BorderSide())),
+                      ),
                     ),
-                  ),
-                  const SizedBox(
-                    width: 10,
-                  ),
-                  Expanded(
-                    child: TextFormField(
-                      controller: _coolDownDaysController,
-                      keyboardType: TextInputType.number,
-                      inputFormatters: [
-                        FilteringTextInputFormatter.allow(RegExp("[0-9]")),
-                      ],
-                      validator: (value) {
-                        if (value == null ||
-                            value.isEmpty ||
-                            int.tryParse(value) == null) {
-                          return 'Please enter a number';
-                        }
-                        return null;
-                      },
-                      decoration: const InputDecoration(
-                          label: Text('Interval Days after First Prompt.'),
-                          border: OutlineInputBorder(borderSide: BorderSide())),
+                    const SizedBox(
+                      width: 10,
                     ),
-                  )
-                ],
-              ),
-              const SizedBox(
-                height: 10,
-              ),
-              MaterialButton(
-                onPressed: _setHypotethicalTodaysDate,
-                color: Colors.blue,
-                child: const Text(
-                  "Set Hypotethical Today's Date",
-                  style: TextStyle(color: Colors.white),
+                    Expanded(
+                      child: TextFormField(
+                        controller: _coolDownDaysController,
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp("[0-9]")),
+                        ],
+                        validator: (value) {
+                          if (value == null ||
+                              value.isEmpty ||
+                              int.tryParse(value) == null) {
+                            return 'Please enter a number';
+                          }
+                          return null;
+                        },
+                        decoration: const InputDecoration(
+                            label: Text('Interval Days after First Prompt.'),
+                            border:
+                                OutlineInputBorder(borderSide: BorderSide())),
+                      ),
+                    )
+                  ],
                 ),
-              ),
-              const SizedBox(
-                height: 10,
-              ),
-              Text(DateTimeExtension.customTime == null
-                  ? "Same as System"
-                  : DateTimeExtension.customTime.toString()),
-              const SizedBox(
-                height: 10,
-              ),
-              Text(
-                "Has Prompted user to Rate App: " +
-                    (_hasPromptedRateApp ? "True" : "False"),
-              ),
-              const SizedBox(
-                height: 10,
-              ),
-              MaterialButton(
-                onPressed: _testShouldRateByDaysCriteria,
-                color: Colors.blue,
-                child: const Text(
-                  "Test",
-                  style: TextStyle(color: Colors.white),
+                const SizedBox(
+                  height: 10,
                 ),
-              ),
-              const SizedBox(
-                height: 10,
-              ),
-              const SizedBox(
-                height: 10,
-              ),
-              MaterialButton(
-                onPressed: _reset,
-                color: Colors.blue,
-                child: const Text(
-                  "Reset",
-                  style: TextStyle(color: Colors.white),
+                MaterialButton(
+                  onPressed: _setHypotethicalTodaysDate,
+                  color: Colors.blue,
+                  child: const Text(
+                    "Set Hypotethical Today's Date",
+                    style: TextStyle(color: Colors.white),
+                  ),
                 ),
-              ),
-              const SizedBox(
-                height: 10,
-              ),
-              MaterialButton(
-                onPressed: _viewLaunchTimesCriteriaExample,
-                color: Colors.blue,
-                child: const Text(
-                  "View Launch Times Criteria Example",
-                  style: TextStyle(color: Colors.white),
+                const SizedBox(
+                  height: 10,
                 ),
-              )
-            ],
+                Text(DateTimeExtension.customTime == null
+                    ? "Same as System"
+                    : DateTimeExtension.customTime.toString()),
+                const SizedBox(
+                  height: 10,
+                ),
+                Text(
+                  "Has Prompted user to Rate App: " +
+                      (_hasPromptedRateApp ? "True" : "False"),
+                ),
+                const SizedBox(
+                  height: 10,
+                ),
+                MaterialButton(
+                  onPressed: _testShouldRateByDaysCriteria,
+                  color: Colors.blue,
+                  child: const Text(
+                    "Test",
+                    style: TextStyle(color: Colors.white),
+                  ),
+                ),
+                const SizedBox(
+                  height: 10,
+                ),
+                const SizedBox(
+                  height: 10,
+                ),
+                MaterialButton(
+                  onPressed: _reset,
+                  color: Colors.blue,
+                  child: const Text(
+                    "Reset",
+                    style: TextStyle(color: Colors.white),
+                  ),
+                ),
+                const SizedBox(
+                  height: 10,
+                ),
+                MaterialButton(
+                  onPressed: _viewLaunchTimesCriteriaExample,
+                  color: Colors.blue,
+                  child: const Text(
+                    "View Launch Times Criteria Example",
+                    style: TextStyle(color: Colors.white),
+                  ),
+                ),
+                MaterialButton(
+                  onPressed: _viewCustomCriteriaExample,
+                  color: Colors.blue,
+                  child: const Text(
+                    "Custom Criteria Example",
+                    style: TextStyle(color: Colors.white),
+                  ),
+                )
+              ],
+            ),
           ),
         ),
       ),
@@ -243,6 +255,11 @@ class _MyHomePageState extends State<MyHomePage> {
   void _viewLaunchTimesCriteriaExample() {
     Navigator.of(context).push(MaterialPageRoute(
         builder: (context) => const LaunchTimesCriteriaExample()));
+  }
+
+  void _viewCustomCriteriaExample() {
+    Navigator.of(context).push(
+        MaterialPageRoute(builder: (context) => const CustomCriteriaExample()));
   }
 }
 
@@ -443,5 +460,19 @@ class _LaunchTimesCriteriaExampleState
       // ignore: avoid_print
       print("Returned False");
     }
+  }
+}
+
+class CustomCriteriaExample extends StatefulWidget {
+  const CustomCriteriaExample({Key? key}) : super(key: key);
+
+  @override
+  _CustomCriteriaExampleState createState() => _CustomCriteriaExampleState();
+}
+
+class _CustomCriteriaExampleState extends State<CustomCriteriaExample> {
+  @override
+  Widget build(BuildContext context) {
+    return Container();
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -471,8 +471,133 @@ class CustomCriteriaExample extends StatefulWidget {
 }
 
 class _CustomCriteriaExampleState extends State<CustomCriteriaExample> {
+  GlobalKey<FormState> _customCriteriaFormKey = GlobalKey();
+
+  final TextEditingController _minCustomCriteriaValueController =
+      TextEditingController();
+  final TextEditingController _coolDownCustomCriteriaIntervalValueController =
+      TextEditingController();
+
+  bool _hasPromptedRateApp = false;
+  int _timesCutsomCriteriaWasMet = 0;
+
   @override
   Widget build(BuildContext context) {
-    return Container();
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("Custom Criteria Example"),
+      ),
+      body: Container(
+        padding: const EdgeInsets.all(10),
+        alignment: Alignment.center,
+        child: Form(
+          key: _customCriteriaFormKey,
+          child: Column(
+            children: [
+              const Text(
+                  "Determine if user should rate app by a custom criterion"),
+              const SizedBox(
+                height: 20,
+              ),
+              Row(
+                children: [
+                  Expanded(
+                    child: TextFormField(
+                      controller: _minCustomCriteriaValueController,
+                      keyboardType: TextInputType.number,
+                      inputFormatters: [
+                        FilteringTextInputFormatter.allow(RegExp("[0-9]")),
+                      ],
+                      validator: (value) {
+                        if (value == null ||
+                            value.isEmpty ||
+                            int.tryParse(value) == null) {
+                          return 'Please enter a number';
+                        }
+                        return null;
+                      },
+                      decoration: const InputDecoration(
+                          label: Text('Minimum custom criteria value'),
+                          border: OutlineInputBorder(borderSide: BorderSide())),
+                    ),
+                  ),
+                  const SizedBox(
+                    width: 10,
+                  ),
+                  Expanded(
+                    child: TextFormField(
+                      controller:
+                          _coolDownCustomCriteriaIntervalValueController,
+                      keyboardType: TextInputType.number,
+                      inputFormatters: [
+                        FilteringTextInputFormatter.allow(RegExp("[0-9]")),
+                      ],
+                      validator: (value) {
+                        if (value == null ||
+                            value.isEmpty ||
+                            int.tryParse(value) == null) {
+                          return 'Please enter a number';
+                        }
+                        return null;
+                      },
+                      decoration: const InputDecoration(
+                          label: Text('Custom criteria interval value'),
+                          border: OutlineInputBorder(borderSide: BorderSide())),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(
+                height: 10,
+              ),
+              Text(
+                "Has Prompted user to Rate App: " +
+                    (_hasPromptedRateApp ? "True" : "False"),
+              ),
+              const SizedBox(
+                height: 10,
+              ),
+              Text(
+                "App Launch Times: $_timesCutsomCriteriaWasMet",
+              ),
+              const SizedBox(
+                height: 10,
+              ),
+              MaterialButton(
+                onPressed: _recordLaunch,
+                color: Colors.blue,
+                child: const Text(
+                  "Record App Launch",
+                  style: TextStyle(color: Colors.white),
+                ),
+              ),
+              const SizedBox(
+                height: 10,
+              ),
+              MaterialButton(
+                onPressed: _testShouldRateByLaunchTimesCriteria,
+                color: Colors.blue,
+                child: const Text(
+                  "Test",
+                  style: TextStyle(color: Colors.white),
+                ),
+              ),
+              const SizedBox(
+                height: 10,
+              ),
+              MaterialButton(
+                onPressed: () =>
+                    _reset().then((_) => _updateAppLaunchTimesInUI()),
+                color: Colors.blue,
+                child: const Text(
+                  "Reset",
+                  style: TextStyle(color: Colors.white),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -232,7 +232,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.2"
+    version: "0.2.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -279,7 +279,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -335,7 +335,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   win32:
     dependency: transitive
     description:

--- a/lib/should_review.dart
+++ b/lib/should_review.dart
@@ -13,9 +13,9 @@ class ShouldReview {
   static Future<bool> shouldReview(
       {Criteria criteria = Criteria.days,
       int minDays = 5,
-      int coolDownDays = 2,
+      int? coolDownDays = 2,
       int minLaunchTimes = 5,
-      int coolDownLaunchTimes = 4,
+      int? coolDownLaunchTimes = 4,
       String? customCriteriaKey,
       int? minCustomCriteriaValue,
       int? coolDownCustomCriteriaInterval}) async {
@@ -43,6 +43,7 @@ class ShouldReview {
         }
 
         if (prefs.getBool(prefInDaysCoolDownMode) ?? false) {
+          if (coolDownDays == null) return false;
           firstLaunchDate = firstLaunchDate.add(Duration(days: minDays));
           if (now.difference(firstLaunchDate).inDays % coolDownDays != 0) {
             return false;
@@ -60,6 +61,7 @@ class ShouldReview {
         // Times Launched Criteria.
         int timesLaunched = prefs.getInt(prefTimesLaunched) ?? 1;
         if (prefs.getBool(prefInTimesLaunchedCoolDownMode) ?? false) {
+          if (coolDownLaunchTimes == null) return false;
           timesLaunched -= minLaunchTimes;
           if (timesLaunched <= 0) return false;
           if (timesLaunched % coolDownLaunchTimes != 0) {
@@ -76,9 +78,7 @@ class ShouldReview {
         break;
       case Criteria.custom:
         // Custom criteria.
-        if (customCriteriaKey == null ||
-            minCustomCriteriaValue == null ||
-            coolDownCustomCriteriaInterval == null) {
+        if (customCriteriaKey == null || minCustomCriteriaValue == null) {
           throw ArgumentError(
               'Custom Criteria requires customCriteriaKey, minCustomCriteriaValue and coolDownCustomCriteriaInterval to be set.');
         }
@@ -87,6 +87,7 @@ class ShouldReview {
             prefs.getInt(prefCustomCriteriaPrefix + customCriteriaKey) ?? 0;
         if (prefs.getBool(prefInCustomCoolDownModePrefix + customCriteriaKey) ??
             false) {
+          if (coolDownCustomCriteriaInterval == null) return false;
           customCriteriaValue -= minCustomCriteriaValue;
           if (customCriteriaValue <= 0) return false;
           if (customCriteriaValue % coolDownCustomCriteriaInterval != 0) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: should_review
 description: A flutter package to determine if you should prompt users to rate your app based on some set metrics.
-version: 0.1.2
+version: 0.2.0
 repository: https://github.com/francis94c/should_review
 
 environment:

--- a/test/should_review_test.dart
+++ b/test/should_review_test.dart
@@ -189,6 +189,17 @@ void main() async {
         false);
   });
 
+  // Custom Criteria
+  test("Return 'false' on first try (custom:test)", () async {
+    await ShouldReviewExtension.reset();
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2),
+        false);
+  });
+
   test("Test Custom Criteria", () async {
     await ShouldReviewExtension.reset(customCriteriaKeys: ["test"]);
     await ShouldReview.recordCustomCriteriaMet("test");

--- a/test/should_review_test.dart
+++ b/test/should_review_test.dart
@@ -191,10 +191,11 @@ void main() async {
 
   // Custom Criteria
   test("Return 'false' on first try (custom:test)", () async {
-    await ShouldReviewExtension.reset();
+    await ShouldReviewExtension.reset(customCriteriaKeys: ["test"]);
     expect(
         await ShouldReview.shouldReview(
             criteria: Criteria.custom,
+            customCriteriaKey: "test",
             minCustomCriteriaValue: 5,
             coolDownCustomCriteriaInterval: 2),
         false);
@@ -240,6 +241,101 @@ void main() async {
         false);
     await ShouldReview.recordCustomCriteriaMet("test");
     expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 5);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        true);
+  });
+
+  test('Verify cooldown behaviour with custom criteria', () async {
+    await ShouldReviewExtension.reset(customCriteriaKeys: ["test"]);
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 1);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        false);
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 2);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        false);
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 3);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        false);
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 4);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        false);
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 5);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        true);
+    // Cool Down Mode.
+    // Coool down launch times = 4
+
+    // So we can still return true for testing purposes.
+    ShouldReviewExtension.resetReturnedTrueTodayFlag();
+
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 6);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        false);
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 7);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        true);
+
+    // So we can still return true for testing purposes.
+    await ShouldReviewExtension.resetReturnedTrueTodayFlag();
+
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 8);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        false);
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 9);
     expect(
         await ShouldReview.shouldReview(
             criteria: Criteria.custom,

--- a/test/should_review_test.dart
+++ b/test/should_review_test.dart
@@ -48,6 +48,21 @@ void main() async {
     expect(await ShouldReview.shouldReview(), true);
   });
 
+  test('Verify behaviour in cool down mode for null days interval', () async {
+    await ShouldReviewExtension.reset();
+    DateTimeExtension.customTime = null;
+    expect(await ShouldReview.shouldReview(), false);
+    DateTimeExtension.customTime =
+        DateTime.now().add(const Duration(days: 5)); // 5 Days in Future
+    expect(await ShouldReview.shouldReview(), true);
+    DateTimeExtension.customTime = DateTimeExtension.customTime!
+        .add(const Duration(days: 1)); // 6 Days in Future.
+    expect(await ShouldReview.shouldReview(), false);
+    DateTimeExtension.customTime = DateTimeExtension.customTime!
+        .add(const Duration(days: 1)); // 7 Days in Future.
+    expect(await ShouldReview.shouldReview(coolDownDays: null), false);
+  });
+
   test("Cannot return 'true' multiple times the same day", () async {
     await ShouldReviewExtension.reset();
     DateTimeExtension.customTime = null;
@@ -163,29 +178,49 @@ void main() async {
     expect(await ShouldReview.shouldReview(), false);
   });
 
-  // Never Rate Region
-  test("Always return false no matter what.", () async {
-    // Days Criteria.
+  test('Verify behaviour in cool down mode for null times launched interval',
+      () async {
     await ShouldReviewExtension.reset();
-    await ShouldReview.neverReview();
-    expect(await ShouldReview.shouldReview(), false);
-    DateTimeExtension.customTime = DateTime.now();
-    expect(await ShouldReview.shouldReview(), false);
-    DateTimeExtension.customTime = DateTimeExtension.customTime!
-        .add(const Duration(days: 5)); // 5 Days in Future.
-    expect(await ShouldReview.shouldReview(), false);
-
-    // Times Launched Criteria.
-    // Defaulr Min Launch Times is 5.
-    await ShouldReviewExtension.reset();
-    await ShouldReview.neverReview();
     await ShouldReview.recordLaunch();
+    expect(await ShouldReview.getTimesAppLaunched(), 1);
+    expect(await ShouldReview.shouldReview(criteria: Criteria.timesLaunched),
+        false);
     await ShouldReview.recordLaunch();
+    expect(await ShouldReview.getTimesAppLaunched(), 2);
+    expect(await ShouldReview.shouldReview(criteria: Criteria.timesLaunched),
+        false);
     await ShouldReview.recordLaunch();
+    expect(await ShouldReview.getTimesAppLaunched(), 3);
+    expect(await ShouldReview.shouldReview(criteria: Criteria.timesLaunched),
+        false);
     await ShouldReview.recordLaunch();
+    expect(await ShouldReview.getTimesAppLaunched(), 4);
+    expect(await ShouldReview.shouldReview(criteria: Criteria.timesLaunched),
+        false);
     await ShouldReview.recordLaunch();
     expect(await ShouldReview.getTimesAppLaunched(), 5);
     expect(await ShouldReview.shouldReview(criteria: Criteria.timesLaunched),
+        true);
+    // Cool Down Mode.
+    // Coool down launch times = 4
+    ShouldReviewExtension.resetReturnedTrueTodayFlag();
+    await ShouldReview.recordLaunch();
+    expect(await ShouldReview.getTimesAppLaunched(), 6);
+    expect(await ShouldReview.shouldReview(criteria: Criteria.timesLaunched),
+        false);
+    await ShouldReview.recordLaunch();
+    expect(await ShouldReview.getTimesAppLaunched(), 7);
+    expect(await ShouldReview.shouldReview(criteria: Criteria.timesLaunched),
+        false);
+    await ShouldReview.recordLaunch();
+    expect(await ShouldReview.getTimesAppLaunched(), 8);
+    expect(await ShouldReview.shouldReview(criteria: Criteria.timesLaunched),
+        false);
+    await ShouldReview.recordLaunch();
+    expect(await ShouldReview.getTimesAppLaunched(), 9);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.timesLaunched, coolDownLaunchTimes: null),
         false);
   });
 
@@ -343,5 +378,216 @@ void main() async {
             coolDownCustomCriteriaInterval: 2,
             customCriteriaKey: "test"),
         true);
+  });
+
+  test('Verify cooldown behaviour with custom criteria for null interval value',
+      () async {
+    await ShouldReviewExtension.reset(customCriteriaKeys: ["test"]);
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 1);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        false);
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 2);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        false);
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 3);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        false);
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 4);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        false);
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 5);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        true);
+    // Cool Down Mode.
+    // Coool down launch times = 4
+
+    // So we can still return true for testing purposes.
+    ShouldReviewExtension.resetReturnedTrueTodayFlag();
+
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 6);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: null,
+            customCriteriaKey: "test"),
+        false);
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 7);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: null,
+            customCriteriaKey: "test"),
+        false); // Normally should return true.
+
+    // So we can still return true for testing purposes.
+    await ShouldReviewExtension.resetReturnedTrueTodayFlag();
+
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 8);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: null,
+            customCriteriaKey: "test"),
+        false);
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 9);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: null,
+            customCriteriaKey: "test"),
+        false); // Normally should return true
+  });
+
+  test("Cannot return 'true' multiple times the same day (Custom criteria)",
+      () async {
+    await ShouldReviewExtension.reset(customCriteriaKeys: ["test"]);
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 1);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        false);
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 2);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        false);
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 3);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        false);
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 4);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        false);
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 5);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        true);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        false);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        false);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        false);
+  });
+
+  // Never Rate Region
+  test("Always return false no matter what.", () async {
+    // Days Criteria.
+    await ShouldReviewExtension.reset();
+    await ShouldReview.neverReview();
+    expect(await ShouldReview.shouldReview(), false);
+    DateTimeExtension.customTime = DateTime.now();
+    expect(await ShouldReview.shouldReview(), false);
+    DateTimeExtension.customTime = DateTimeExtension.customTime!
+        .add(const Duration(days: 5)); // 5 Days in Future.
+    expect(await ShouldReview.shouldReview(), false);
+
+    // Times Launched Criteria.
+    // Default Min Launch Times is 5.
+    await ShouldReviewExtension.reset();
+    await ShouldReview.neverReview();
+    await ShouldReview.recordLaunch();
+    await ShouldReview.recordLaunch();
+    await ShouldReview.recordLaunch();
+    await ShouldReview.recordLaunch();
+    await ShouldReview.recordLaunch();
+    expect(await ShouldReview.getTimesAppLaunched(), 5);
+    expect(await ShouldReview.shouldReview(criteria: Criteria.timesLaunched),
+        false);
+
+    // Custom Criteria.
+    // Defaulr Min Launch Times is 5.
+    await ShouldReviewExtension.reset(customCriteriaKeys: ["test"]);
+    await ShouldReview.neverReview();
+    await ShouldReview.recordCustomCriteriaMet("test");
+    await ShouldReview.recordCustomCriteriaMet("test");
+    await ShouldReview.recordCustomCriteriaMet("test");
+    await ShouldReview.recordCustomCriteriaMet("test");
+    await ShouldReview.recordCustomCriteriaMet("test");
+    expect(await ShouldReview.getTimesCustomCriteriaWasMet("test"), 5);
+    expect(
+        await ShouldReview.shouldReview(
+            criteria: Criteria.custom,
+            minCustomCriteriaValue: 5,
+            coolDownCustomCriteriaInterval: 2,
+            customCriteriaKey: "test"),
+        false);
   });
 }


### PR DESCRIPTION
* Use custom criteria. Use string keys to indicate custom criteria, e.g. `made_purchase`.
* Make cool down intervals nullable.
* More tests.